### PR TITLE
Fix player list in backfill match properties been incorrect.

### DIFF
--- a/Assets/Scripts/Matchplay/Server/ServerGameManager.cs
+++ b/Assets/Scripts/Matchplay/Server/ServerGameManager.cs
@@ -166,10 +166,10 @@ namespace Matchplay.Server
 
         void UserLeft(UserData leftUser)
         {
-            Debug.Log($"{leftUser} left the game");
-            m_Backfiller.RemovePlayerFromMatch(leftUser.userAuthId);
+            var playerCount = m_Backfiller.RemovePlayerFromMatch(leftUser.userAuthId);
             m_MultiplayAllocationService.RemovePlayer();
-            var playerCount = m_NetworkServer.PlayerCount;
+
+            Debug.Log($"player '{leftUser?.userName}' left the game, {playerCount} players left in game.");
             if (playerCount <= 0)
             {
 #pragma warning disable 4014
@@ -210,6 +210,7 @@ namespace Matchplay.Server
 
         async Task CloseServer()
         {
+            Debug.Log($"Closing Server");
             await m_Backfiller.StopBackfill();
             Dispose();
             Application.Quit();


### PR DESCRIPTION
Repro steps:
 - upload build on udash
 - player 1 join the game via matchmaking
 - player 2 join the same game via matchmaking
 - player 1 or 2 leave the match
 - same player matchmake again
The player should be put back into the same match again.
If both players leave the game, the server should delete the backfill ticket and stop itself