### PR TITLE
Remote backfill bug

### DIFF
--- a/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
+++ b/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
@@ -136,7 +136,11 @@ namespace Matchplay.Server
                 }
                 else
                 {
-                    m_LocalBackfillTicket = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
+                    var remoteBackfillTicket = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
+                    if (!m_LocalDataDirty)
+                    {
+                        m_LocalBackfillTicket = remoteBackfillTicket;
+                    }
                 }
 
                 if (!NeedsPlayers())

--- a/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
+++ b/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
@@ -129,19 +129,27 @@ namespace Matchplay.Server
         {
             while (Backfilling)
             {
-                if (m_LocalDataDirty)
+                do
                 {
-                    await MatchmakerService.Instance.UpdateBackfillTicketAsync(m_LocalBackfillTicket.Id, m_LocalBackfillTicket);
-                    m_LocalDataDirty = false;
-                }
-                else
-                {
-                    var remoteBackfillTicket = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
-                    if (!m_LocalDataDirty)
+                    if (m_LocalDataDirty)
                     {
-                        m_LocalBackfillTicket = remoteBackfillTicket;
+                        await MatchmakerService.Instance.UpdateBackfillTicketAsync(m_LocalBackfillTicket.Id, m_LocalBackfillTicket);
+                        m_LocalDataDirty = false;
                     }
-                }
+                    else
+                    {
+                        var newBackfill = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
+                        if (!m_LocalDataDirty)
+                        {
+                            m_LocalBackfillTicket = newBackfill;
+                        }
+                        else
+                        {
+                            Debug.Log("Local data became dirty during backfill ticket approval!");
+                            await Task.Delay(k_TicketCheckMs);
+                        }
+                    }
+                } while (m_LocalDataDirty);
 
                 if (!NeedsPlayers())
                 {

--- a/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
+++ b/Assets/Scripts/Matchplay/Server/Services/MatchplayBackfiller.cs
@@ -129,27 +129,23 @@ namespace Matchplay.Server
         {
             while (Backfilling)
             {
-                do
+                if (m_LocalDataDirty)
                 {
-                    if (m_LocalDataDirty)
+                    await MatchmakerService.Instance.UpdateBackfillTicketAsync(m_LocalBackfillTicket.Id, m_LocalBackfillTicket);
+                    m_LocalDataDirty = false;
+                }
+                else
+                {
+                    var newBackfill = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
+                    if (!m_LocalDataDirty)
                     {
-                        await MatchmakerService.Instance.UpdateBackfillTicketAsync(m_LocalBackfillTicket.Id, m_LocalBackfillTicket);
-                        m_LocalDataDirty = false;
+                        m_LocalBackfillTicket = newBackfill;
                     }
                     else
                     {
-                        var newBackfill = await MatchmakerService.Instance.ApproveBackfillTicketAsync(m_LocalBackfillTicket.Id);
-                        if (!m_LocalDataDirty)
-                        {
-                            m_LocalBackfillTicket = newBackfill;
-                        }
-                        else
-                        {
-                            Debug.Log("Local data became dirty during backfill ticket approval!");
-                            await Task.Delay(k_TicketCheckMs);
-                        }
+                        Debug.Log("Local data became dirty during backfill ticket approval!");
                     }
-                } while (m_LocalDataDirty);
+                }
 
                 if (!NeedsPlayers())
                 {


### PR DESCRIPTION
This fixes a nasty bug where a player can be removed during the time where you are fetching the remote backfill ticket.

If the result is assigned to m_LocalBackfillTicket without checking if the data became dirty during the task, then your server will be in an invalid state until it shuts down.

Strangely, if the backfill ticket says that a particular userId is on the backfill ticket, that same userId will be placed in a different match should they queue again, instead of being placed on the same server again. This can lead to a user causing many or ALL servers to be allocated by their userId. This feels like a bug with the matchmaker itself as IMO a user who is already part of a backfill ticket should be assigned to the same match they're "already in", instead of allocating new servers for that player. Alternatively, the matchmaker should update the ticket to reflect the reality of the situation and let the individual server decide whether to kick the player out if they are truly currently in 2 matches.